### PR TITLE
changed AppendDice to AddDice

### DIFF
--- a/dice/deck.go
+++ b/dice/deck.go
@@ -37,6 +37,6 @@ func (d *Deck) DealDice(num_dice int) (Dices, error) {
 	}
 }
 
-func (d *Deck) AppendDice(new_dice Dice) {
+func (d *Deck) AddDice(new_dice Dice) {
 	d.Dices = append(d.Dices, new_dice)
 }

--- a/dice/deck_test.go
+++ b/dice/deck_test.go
@@ -99,11 +99,11 @@ func TestDealDiceFailure(t *testing.T) {
 	}
 }
 
-func TestAppendDice(t *testing.T) {
+func TestAddDice(t *testing.T) {
 	const TEST_N_SIDES = 20
 	deck := initBasicTestDeck(DEFAULT_DECK_SIZE)
 	my_dice := InitDefaultDice(TEST_N_SIDES)
-	deck.AppendDice(my_dice)
+	deck.AddDice(my_dice)
 	// I am getting back the dice that I created
 	dices, _ := deck.DealDice(1)
 

--- a/zombie_dice/zombie_dice.go
+++ b/zombie_dice/zombie_dice.go
@@ -78,7 +78,7 @@ func players_turn(deck dice.Deck, player_name string) (int, error) {
 			} else {
 				// Since walks get replayed we have to
 				// put them back in the deck
-				deck.AppendDice(d)
+				deck.AddDice(d)
 			}
 		}
 


### PR DESCRIPTION
I was going to add interfaces, but ran into problems, so I am just submitting this.

Problems: 

Since our AIs will take different parameters it will create different functions signatures, so we cannot user interface for that. And we cannot specify shouldKeepGoing() with different signatures in the interface:

```
type Addy interface{
	add(x, y int) int
	add(x, y, z int) int  // duplicate method add
}
```

Unless I am missing something, something like this is not allowed.

If the above does not work, the only other option I see is to pass all the possible parameters to every AI, and they will just use what they need. But I am not sure this would be better deign, probably not.




